### PR TITLE
include yellowpaper in HoprChannels spec

### DIFF
--- a/audits/hopr-channels/spec.md
+++ b/audits/hopr-channels/spec.md
@@ -70,13 +70,5 @@ HoprChannels should:
 
 ## Learning more about HoprChannels
 
-Our [yellowpaper](https://github.com/hoprnet/hoprnet/blob/whitepaper-v2/docs/yellowpaper/yellowpaper.pdf) described in detail how our whole protocol works.
-Sections A,B,C are the most relevant for the audit, but we suggest to read it all to get a whole picture of the protocol.
-
-## Differences between the yellow paper and HoprChannels
-
-While the concept remains the same, there are some minor differences between how the current implementation of HoprChannels is and what we describe in the yellow paper.
-Below we provide a list of said differences.
-
-- diff A
-- diff B
+Our [yellowpaper](https://github.com/hoprnet/hoprnet/blob/whitepaper-v2/docs/yellowpaper/yellowpaper.pdf) described in detail how our protocol works.
+Sections 5 & 6 are the most relevant for the audit, but we suggest to read it all to get a whole picture of the protocol.

--- a/audits/hopr-channels/spec.md
+++ b/audits/hopr-channels/spec.md
@@ -67,3 +67,16 @@ HoprChannels should:
   - source & destination must not be null addresses
   - increment `ticketEpoch`
   - if channel is `WAITING_FOR_COMMITMENT`, set it to `OPEN`
+
+## Learning more about HoprChannels
+
+Our [yellowpaper](https://github.com/hoprnet/hoprnet/blob/whitepaper-v2/docs/yellowpaper/yellowpaper.pdf) described in detail how our whole protocol works.
+Sections A,B,C are the most relevant for the audit, but we suggest to read it all to get a whole picture of the protocol.
+
+## Differences between the yellow paper and HoprChannels
+
+While the concept remains the same, there are some minor differences between how the current implementation of HoprChannels is and what we describe in the yellow paper.
+Below we provide a list of said differences.
+
+- diff A
+- diff B


### PR DESCRIPTION
Point auditors to the YP, YP will be audited to reflect what we have implemented.
Before we send audit spec out to the auditors, we will be updating the link to one that includes a commit hash so it doesn't change afterwards.